### PR TITLE
Serve site at squiggles.slesa.com.np custom domain

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,7 +4,6 @@ import sitemap from '@astrojs/sitemap';
 import svelte from '@astrojs/svelte';
 
 export default defineConfig({
-  site: 'https://slesaad.github.io',
-  base: '/squiggly-lines',
+  site: 'https://squiggles.slesa.com.np',
   integrations: [mdx(), sitemap(), svelte()],
 });

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+squiggles.slesa.com.np

--- a/src/components/GradScrollytelling.svelte
+++ b/src/components/GradScrollytelling.svelte
@@ -553,7 +553,7 @@
         {#if activePanel === 'ending'}
           <video
             class="party-video"
-            src="/squiggly-lines/videos/graduation/surprise-party.mp4"
+            src="/videos/graduation/surprise-party.mp4"
             muted={videoMuted}
             autoplay
             playsinline

--- a/src/content/posts/caden-grad.mdx
+++ b/src/content/posts/caden-grad.mdx
@@ -11,9 +11,9 @@ import GradScrollytelling from '../../components/GradScrollytelling.svelte';
 
 <GradScrollytelling
   client:load
-  cadenPhoto="/squiggly-lines/images/caden.jpg"
-  cadenTriumphantPhoto="/squiggly-lines/images/caden-flying.jpg"
-  cadenCryingPhoto="/squiggly-lines/images/caden-crying.jpg"
+  cadenPhoto="/images/caden.jpg"
+  cadenTriumphantPhoto="/images/caden-flying.jpg"
+  cadenCryingPhoto="/images/caden-crying.jpg"
   steps={[
     // Act 1: The Promotion
     { kind: 'intro-greeting', caption: '**hey, Master Caden!** 🎓', duration: 4500 },
@@ -34,71 +34,71 @@ import GradScrollytelling from '../../components/GradScrollytelling.svelte';
     { kind: 'map-intro', caption: "here's what your friends and family have to say. **from all around the world.**", duration: 4500 },
 
     { kind: 'video', name: 'Vinu & Sandip', locationKey: 'australia',
-      src: '/squiggly-lines/videos/graduation/Vinu-n-Sandip-Australia.mp4',
+      src: '/videos/graduation/Vinu-n-Sandip-Australia.mp4',
       caption: '**vinu & sandip** — sydney, australia. 🇦🇺', duration: 'video-end' },
 
     { kind: 'video', name: 'Aha', locationKey: 'australia',
-      src: '/squiggly-lines/videos/graduation/Neha-n-Aha-Australia.mp4',
+      src: '/videos/graduation/Neha-n-Aha-Australia.mp4',
       caption: '**aha** — sydney, australia. 🇦🇺', duration: 'video-end' },
 
     { kind: 'video', name: 'Neha', locationKey: 'australia',
-      src: '/squiggly-lines/videos/graduation/neha-australia.mp4',
+      src: '/videos/graduation/neha-australia.mp4',
       caption: '**neha** — sydney, australia. 🇦🇺', duration: 'video-end' },
 
     { kind: 'video', name: 'Chase', locationKey: 'saudiarabia',
-      src: '/squiggly-lines/videos/graduation/Chase-saudiarabia.mp4',
+      src: '/videos/graduation/Chase-saudiarabia.mp4',
       caption: '**chase** — riyadh, saudi arabia. 🇸🇦', duration: 'video-end' },
 
     { kind: 'video', name: 'Mamu & Daddy', locationKey: 'nepal',
-      src: '/squiggly-lines/videos/graduation/MamuDaddy-nepal.mp4',
+      src: '/videos/graduation/MamuDaddy-nepal.mp4',
       caption: '**mamu & daddy** — nepal. 🇳🇵', duration: 'video-end' },
 
     { kind: 'video', name: 'Brandon DANG', locationKey: 'pennsylvinia',
-      src: '/squiggly-lines/videos/graduation/BrandonDang-pennsylvinia.mp4',
+      src: '/videos/graduation/BrandonDang-pennsylvinia.mp4',
       caption: '**brandon** — pennsylvania.', duration: 'video-end' },
 
     { kind: 'video', name: 'Colette', locationKey: 'northcarolina',
-      src: '/squiggly-lines/videos/graduation/colette-northcarolina.mp4',
+      src: '/videos/graduation/colette-northcarolina.mp4',
       caption: '**colette** — north carolina.', duration: 'video-end' },
 
     { kind: 'video', name: 'Colette (again!)', locationKey: 'northcarolina',
-      src: '/squiggly-lines/videos/graduation/colette2-northcarolina.mp4',
+      src: '/videos/graduation/colette2-northcarolina.mp4',
       caption: '**colette, take two.**', duration: 'video-end' },
 
     { kind: 'video', name: 'Kristen', locationKey: 'nagshead',
-      src: '/squiggly-lines/videos/graduation/Kristen-nagshead-northcarolina.mp4',
+      src: '/videos/graduation/Kristen-nagshead-northcarolina.mp4',
       caption: '**kristen** — nags head, north carolina.', duration: 'video-end' },
 
     { kind: 'video', name: 'Liesl & Kevin', locationKey: 'atlanta',
-      src: '/squiggly-lines/videos/graduation/Liesl-n-Kevin-atlanta.mp4',
+      src: '/videos/graduation/Liesl-n-Kevin-atlanta.mp4',
       caption: '**liesl** — atlanta.', duration: 'video-end' },
 
     { kind: 'video', name: 'Angela', locationKey: 'atlanta',
-      src: '/squiggly-lines/videos/graduation/Angela-atlanta.mp4',
+      src: '/videos/graduation/Angela-atlanta.mp4',
       caption: '**angela** — atlanta.', duration: 'video-end' },
 
     { kind: 'video', name: 'Mom & Addison', locationKey: 'atlanta',
-      src: '/squiggly-lines/videos/graduation/MomAddison-atlanta.mp4',
+      src: '/videos/graduation/MomAddison-atlanta.mp4',
       caption: '**mom & addison** — atlanta.', duration: 'video-end' },
 
     { kind: 'video', name: 'Jenna & Max', locationKey: 'atlanta',
-      src: '/squiggly-lines/videos/graduation/Jenna-n-Max-atlanta.mp4',
+      src: '/videos/graduation/Jenna-n-Max-atlanta.mp4',
       caption: '**jenna & max** — atlanta.', duration: 'video-end' },
 
     { kind: 'video', name: 'Saam', locationKey: 'nashville',
-      src: '/squiggly-lines/videos/graduation/Saam-nashville.mp4',
+      src: '/videos/graduation/Saam-nashville.mp4',
       caption: '**saam** — nashville.', duration: 'video-end' },
 
     { kind: 'video', name: 'Ben', locationKey: 'texas',
-      src: '/squiggly-lines/videos/graduation/Ben-texas.mp4',
+      src: '/videos/graduation/Ben-texas.mp4',
       caption: '**ben** — texas.', duration: 'video-end' },
 
     { kind: 'video', name: 'Blaine & Ramona', locationKey: 'phoenixalabama',
-      src: '/squiggly-lines/videos/graduation/BlaineRamona-phoenixalabama.mp4',
+      src: '/videos/graduation/BlaineRamona-phoenixalabama.mp4',
       caption: '**blaine & ramona** — phenix city, AL.', duration: 'video-end' },
 
     { kind: 'video', name: 'Dad', locationKey: 'alabama',
-      src: '/squiggly-lines/videos/graduation/Dad-alabama.mp4',
+      src: '/videos/graduation/Dad-alabama.mp4',
       caption: '**dad** — alabama.', duration: 'video-end' },
 
     { kind: 'map-home', name: 'Home', locationKey: 'huntsville',


### PR DESCRIPTION
## Summary
- Switch astro `site` to `https://squiggles.slesa.com.np` and drop the `/squiggly-lines` `base` (since the site now lives at the root of a custom subdomain rather than at `slesaad.github.io/squiggly-lines/`)
- Add `public/CNAME` containing `squiggles.slesa.com.np` so GitHub Pages picks up the custom domain after build
- Replace hardcoded `/squiggly-lines/` asset paths in `caden-grad.mdx` and `GradScrollytelling.svelte` (no longer prefixed now that `base` is gone)

## Out-of-repo follow-ups (after merge + deploy)
- Add CNAME record `squiggles → slesaad.github.io.` in Netlify DNS
- Set custom domain to `squiggles.slesa.com.np` in repo Settings → Pages, then enable Enforce HTTPS once the cert provisions

## Test plan
- [x] GitHub Actions Astro deploy workflow runs green
- [x] After DNS + Pages config, `https://squiggles.slesa.com.np/` loads with valid cert
- [x] Caden grad post images load (e.g. `/images/caden.jpg`)
- [x] Caden grad post videos play (e.g. `/videos/graduation/Vinu-n-Sandip-Australia.mp4`)
- [x] Surprise-party closing video plays in scrollytelling
- [x] No 404s on assets across the site